### PR TITLE
allow configuration of extension of daily files

### DIFF
--- a/lua/512-words/buffer.lua
+++ b/lua/512-words/buffer.lua
@@ -222,6 +222,7 @@ function M.open()
 	local yearMonth = os.date("%Y-%m")
 	local storage_dir = vim.fn.expand(config.options.storage_directory)
 	local dir_yearMonth = storage_dir .. "/512-words/" .. tostring(yearMonth)
+	local file_ext = config.options.file_extension
 
 	if vim.fn.isdirectory(dir_yearMonth) == 0 then
 		vim.fn.mkdir(dir_yearMonth, "p")
@@ -229,7 +230,7 @@ function M.open()
 
 	M.curr_dir = dir_yearMonth
 
-	local filepath = dir_yearMonth .. "/" .. today .. ".txt"
+	local filepath = dir_yearMonth .. "/" .. today .. file_ext
 	if vim.fn.filereadable(filepath) == 1 then
 		reopen(filepath, config.options)
 	else

--- a/lua/512-words/config.lua
+++ b/lua/512-words/config.lua
@@ -22,6 +22,7 @@ local defaults = {
 	split = true, -- If true, will create the journal window as a split, false creates a new buffer window
 	words = 0x200, -- (0x200 == 512) Set the number of words required to get a star ⭐
 	storage_directory = tostring(vim.fn.stdpath("data")), -- Where all your files are saved, if you change the default "~" will be expanded for you.
+	file_extension = ".txt", -- allow configuration
 
 	-- NOTE: Do not alter the folder/file naming structure in the saved directory. The files are read to determine stars.
 }


### PR DESCRIPTION
When editing prose I rely some things specific to my markdown settings instead of plain text. This PR adds a configuration option 'file_extension'.