### PR TITLE
set filetype by extension, allow prefix on date

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ local defaults = {
 	words = 0x200, -- (0x200 == 512) Set the number of words required to get a star ⭐
 	storage_directory = tostring(vim.fn.stdpath("data")), -- Where all your files are saved, if you change the default "~" will be expanded for you.
 	file_extension = ".txt", -- allow configuration
+	date_prefix = "", -- useful to add header tag to date for markdown
 
 	-- NOTE: Do not alter the folder/file naming structure in the saved directory. The files are read to determine stars.
 }

--- a/lua/512-words/buffer.lua
+++ b/lua/512-words/buffer.lua
@@ -197,7 +197,12 @@ end
 ---@param opts Options512
 ---@param filename string
 local function create(filename, opts)
-	local lines = { os.date("%A %B %d, %Y"), "", "" }
+	local lines
+	if opts.date_prefix == "" then
+		lines = { os.date("%A %B %d, %Y"), "", "" }
+	else
+		lines = { string.format("%s %s", opts.date_prefix, os.date("%A %B %d, %Y")), "", "" }
+	end
 	local buf = vim.api.nvim_create_buf(true, false)
 
 	M.buf = buf
@@ -215,6 +220,8 @@ local function create(filename, opts)
 		init_buffer(opts)
 	end
 	vim.api.nvim_win_set_cursor(0, { 3, 0 })
+	local ft = vim.filetype.match({ filename = filename })
+	vim.api.nvim_set_option_value("filetype", ft, { buf = M.buf })
 end
 
 function M.open()

--- a/lua/512-words/config.lua
+++ b/lua/512-words/config.lua
@@ -21,10 +21,10 @@ local defaults = {
 	floating_calendar_keybind = "g.", -- Keybind to toggle calendar in normal mode.
 	split = true, -- If true, will create the journal window as a split, false creates a new buffer window
 	words = 0x200, -- (0x200 == 512) Set the number of words required to get a star ⭐
+	-- NOTE: Do not alter the folder/file naming structure in the saved directory. The files are read to determine stars.
 	storage_directory = tostring(vim.fn.stdpath("data")), -- Where all your files are saved, if you change the default "~" will be expanded for you.
 	file_extension = ".txt", -- allow configuration
-
-	-- NOTE: Do not alter the folder/file naming structure in the saved directory. The files are read to determine stars.
+	date_prefix = "", -- allows for a markdown header marker
 }
 
 ---@type Options512


### PR DESCRIPTION
Hi, another two small tweaks.

When the new day's file is created, it does not have a filetype. This sets the filetype based on its extension.

I got tired of the Markdown linter complaining that the first line of each day's file didn't have a header (#). I added a date_prefix to options, and if that is not an empty string, it is inserted in front of the date.

I'm still using this daily. Hitting even 0x100 words is sometimes a challenge, but so far so good.